### PR TITLE
fix(auth): Remove refresh token from JSON response

### DIFF
--- a/backend/WebAPI/Controllers/AuthController.cs
+++ b/backend/WebAPI/Controllers/AuthController.cs
@@ -44,8 +44,7 @@ namespace WebAPI.Controllers
 				{
 					result.Data.AccessToken,
 					result.Data.ExpiresAt,
-					result.Data.Email,
-					result.Data.RefreshToken
+					result.Data.Email
 				},
 				errors = Array.Empty<string>(),
 				errorCode = (string?)null
@@ -79,7 +78,6 @@ namespace WebAPI.Controllers
 					result.Data.AccessToken,
 					result.Data.ExpiresAt,
 					result.Data.Email,
-					result.Data.RefreshToken
 				},
 				errors = Array.Empty<string>(),
 				errorCode = (string?)null
@@ -128,7 +126,6 @@ namespace WebAPI.Controllers
 					result.Data.AccessToken,
 					result.Data.ExpiresAt,
 					result.Data.Email,
-					result.Data.RefreshToken
 				},
 				errors = Array.Empty<string>(),
 				errorCode = (string?)null

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,6 +42,15 @@ services:
     depends_on:
       - postgres
     restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --spider -q http://localhost:5000/swagger || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # 3. Nginx
   nginx:
@@ -56,11 +65,10 @@ services:
     volumes:
       - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
-      app_network:
-        aliases:
-          - eventmanagement_backend
+      - app_network
 
 volumes:
   postgres_data:

--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -17,6 +17,9 @@ export class AuthInterceptor implements HttpInterceptor {
   constructor(private store: Store<AuthState>) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    req = req.clone({
+      withCredentials: true,
+    });
     if (
       req.url.includes('/api/Auth/login') ||
       req.url.includes('/api/Auth/register') ||
@@ -27,7 +30,6 @@ export class AuthInterceptor implements HttpInterceptor {
 
     return this.addTokenToRequest(req, next);
   }
-
   private addTokenToRequest(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return this.store.select(selectAccessToken).pipe(
       take(1),

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
     return this.http.post<AuthResult>(`${this.apiUrl}/login`, data);
   }
 
-  refresh(data: RefreshTokenRequestDto, accessToken: string): Observable<AuthResult> {
-    return this.http.post<AuthResult>(`${this.apiUrl}/refresh`, data);
+  refresh(): Observable<AuthResult> {
+    return this.http.post<AuthResult>(`${this.apiUrl}/refresh`, {});
   }
 }

--- a/frontend/src/app/models/auth/AuthResponse.ts
+++ b/frontend/src/app/models/auth/AuthResponse.ts
@@ -2,5 +2,4 @@ export interface AuthResponse {
   accessToken: string;
   expiresAt: string | number;
   email: string;
-  refreshToken?: string;
 }

--- a/frontend/src/app/store/auth/auth.reducer.ts
+++ b/frontend/src/app/store/auth/auth.reducer.ts
@@ -7,9 +7,6 @@ import { jwtDecode } from 'jwt-decode';
 function setStorage(response: AuthResponse): DecodedToken | null {
   try {
     localStorage.setItem('accessToken', response.accessToken);
-
-    localStorage.setItem('refreshToken', response.refreshToken ?? '');
-
     const user = jwtDecode<DecodedToken>(response.accessToken);
     return user;
   } catch (e) {
@@ -17,11 +14,9 @@ function setStorage(response: AuthResponse): DecodedToken | null {
     return null;
   }
 }
-
 // Допоміжна функція для очищення
 function clearStorageAndState(): AuthState {
   localStorage.removeItem('accessToken');
-  localStorage.removeItem('refreshToken');
   return initialAuthState;
 }
 
@@ -55,12 +50,10 @@ export const authReducer = createReducer(
         isLoading: false,
         error: null,
         accessToken: authResponse.accessToken,
-        refreshToken: authResponse.refreshToken ?? null,
         user: user,
       };
     }
   ),
-
   // --- Невдача ---
   on(
     AuthActions.loginFailure,
@@ -80,11 +73,8 @@ export const authReducer = createReducer(
 
   // --- Завантаження зі сховища при старті ---
   on(AuthActions.loadAuthFromStorage, (state): AuthState => {
-    const accessToken = localStorage.getItem('accessToken');
-    const refreshToken = localStorage.getItem('refreshToken'); // localStorage.getItem() повертає string | null, що коректно
-
-    if (!accessToken || !refreshToken) {
-      // Якщо null або "", це спрацює
+    const accessToken = localStorage.getItem('accessToken'); // ИЗМЕНЕНИЕ: Больше не читаем refreshToken из localStorage // const refreshToken = localStorage.getItem('refreshToken'); // <-- УДАЛЕНО // ИЗМЕНЕНИЕ: Убираем проверку на refreshToken
+    if (!accessToken) {
       return initialAuthState;
     }
 
@@ -99,11 +89,10 @@ export const authReducer = createReducer(
       return {
         ...state,
         accessToken: accessToken,
-        refreshToken: refreshToken,
         user: user,
       };
     } catch (error) {
-      return clearStorageAndState(); // Невалідний токен
+      return clearStorageAndState();
     }
   })
 );

--- a/frontend/src/app/store/auth/auth.selectors.ts
+++ b/frontend/src/app/store/auth/auth.selectors.ts
@@ -12,5 +12,3 @@ export const selectIsLoggedIn = createSelector(selectAuthState, (state) => !!sta
 export const selectCurrentUser = createSelector(selectAuthState, (state) => state.user);
 
 export const selectAccessToken = createSelector(selectAuthState, (state) => state.accessToken);
-
-export const selectRefreshToken = createSelector(selectAuthState, (state) => state.refreshToken);

--- a/frontend/src/app/store/auth/auth.state.ts
+++ b/frontend/src/app/store/auth/auth.state.ts
@@ -1,6 +1,6 @@
 export interface AuthState {
   accessToken: string | null;
-  refreshToken: string | null;
+
   user: DecodedToken | null;
   isLoading: boolean;
   error: string | null;
@@ -8,7 +8,7 @@ export interface AuthState {
 
 export const initialAuthState: AuthState = {
   accessToken: null,
-  refreshToken: null,
+
   user: null,
   isLoading: false,
   error: null,

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,18 +1,35 @@
 server {
     listen 80;
-    server_name _;
+    server_name localhost; 
 
-    location /api {
-        proxy_pass http://eventmanagement_backend:5000;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+
+    location /api/ {
+
+        proxy_pass http://backend:5000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location / {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        try_files $uri /index.html;
+
+    location = /swagger {
+        return 301 /swagger/;
+    }
+
+    location /swagger/ {
+        rewrite ^/swagger/$ /swagger/index.html break;
+        proxy_pass http://backend:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
The refresh token is now set by the backend exclusively in an HttpOnly cookie and has been removed from the response bodies of /login, /register, and /refresh.

This resolves the vulnerability where the frontend was saving it to localStorage and completes the transition to secure cookie-based authentication.